### PR TITLE
refactor: find the best not the first match

### DIFF
--- a/babble/nlp/engine.py
+++ b/babble/nlp/engine.py
@@ -144,23 +144,26 @@ class Engine:
             return longest_alternatives[0]
         else:
             alternatives_validity = {
-                alternative: alternative.validity
+                alternative: alternative.validity()
                 for alternative in longest_alternatives
             }
+            log.info(
+                f"Alternative intents{[(alternative.intent, alternative.validity()) for alternative in alternatives_validity]}"
+            )
             alternative = max(alternatives_validity, key=alternatives_validity.get)
             return alternative
 
     def evaluate(self, phrase: str) -> Optional[Understanding]:
         """Returns the Understanding of the given phrase. If phrase could not
         be understood None is returnd"""
-    
+
         # Try to match the given phrase with intents.
         #
-        # For performance improvements intents are filtered based on rule length 
-        # so that rules of intent matches nearly the length of the phrase. 
-        # Rules which are too long or short might match, but are not taken into 
+        # For performance improvements intents are filtered based on rule length
+        # so that rules of intent matches nearly the length of the phrase.
+        # Rules which are too long or short might match, but are not taken into
         # account anyway because of the validity calculation of the match.
-        
+
         alternatives = []
         start = time.perf_counter()
         intents_to_test = self._filter_intents_by_lenght(phrase)

--- a/babble/nlp/engine.py
+++ b/babble/nlp/engine.py
@@ -147,7 +147,7 @@ class Engine:
                 alternative: alternative.validity()
                 for alternative in longest_alternatives
             }
-            log.info(
+            log.debug(
                 f"Alternative intents{[(alternative.intent, alternative.validity()) for alternative in alternatives_validity]}"
             )
             alternative = max(alternatives_validity, key=alternatives_validity.get)
@@ -174,10 +174,6 @@ class Engine:
 
         if alternatives:
             understanding = self._get_best_match(alternatives)
-            stop = time.perf_counter()
-            log.info(
-                f"Evaluated {len(self.intents)} intents in {stop - start:0.4f} seconds"
-            )
             return understanding
         stop = time.perf_counter()
         log.info(

--- a/babble/nlp/engine.py
+++ b/babble/nlp/engine.py
@@ -157,29 +157,33 @@ class Engine:
         """Returns the Understanding of the given phrase. If phrase could not
         be understood None is returnd"""
 
+        understandings = []
+        start = time.perf_counter()
+
         # Try to match the given phrase with intents.
         #
         # For performance improvements intents are filtered based on rule length
         # so that rules of intent matches nearly the length of the phrase.
         # Rules which are too long or short might match, but are not taken into
         # account anyway because of the validity calculation of the match.
-
-        alternatives = []
-        start = time.perf_counter()
         intents_to_test = self._filter_intents_by_lenght(phrase)
+
+        # Get all understanding
         for intent in intents_to_test:
             understanding = self._evaluate_intent(intent, phrase)
             if understanding is not None:
-                alternatives.append(understanding)
+                understandings.append(understanding)
 
-        if alternatives:
-            understanding = self._get_best_match(alternatives)
-            return understanding
+        if understandings:
+            result = self._get_best_match(understandings)
+        else:
+            result = None
+
         stop = time.perf_counter()
-        log.info(
+        log.debug(
             f"Evaluated {len(self.intents)} intents in {stop - start:0.4f} seconds"
         )
-        return None
+        return result
 
     def _expand_classifiers(
         self, classifiers: List[str], expanded_classifiers: List[str]


### PR DESCRIPTION
Instead of giving the first matched intent, the engine takes the longest match (with the max amount of classifiers). If there is more than one intent with this value, the one with the biggest validity is chosen. 