### PR TITLE
fix: accept only full word match as an exact match

### DIFF
--- a/babble/nlp/engine.py
+++ b/babble/nlp/engine.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Optional, Dict, List, Tuple, Union
 
-from babble.nlp.parser import IntentTransformer, RuleTransformer, create_parser
+from babble.nlp.parser import IntentTransformer, RuleTransformer, create_parser, prepare_phrase
 
 log = logging.getLogger("babble")
 
@@ -159,7 +159,7 @@ class Engine:
 
         understandings = []
         start = time.perf_counter()
-
+        phrase = prepare_phrase(phrase)
         # Try to match the given phrase with intents.
         #
         # For performance improvements intents are filtered based on rule length

--- a/babble/nlp/engine.py
+++ b/babble/nlp/engine.py
@@ -4,7 +4,12 @@ import logging
 import time
 from typing import Optional, Dict, List, Tuple, Union
 
-from babble.nlp.parser import IntentTransformer, RuleTransformer, create_parser, prepare_phrase
+from babble.nlp.parser import (
+    IntentTransformer,
+    RuleTransformer,
+    create_parser,
+    remove_apostrophe,
+)
 
 log = logging.getLogger("babble")
 
@@ -159,7 +164,7 @@ class Engine:
 
         understandings = []
         start = time.perf_counter()
-        phrase = prepare_phrase(phrase)
+        phrase = remove_apostrophe(phrase)
         # Try to match the given phrase with intents.
         #
         # For performance improvements intents are filtered based on rule length

--- a/babble/nlp/parser.py
+++ b/babble/nlp/parser.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import List, Dict, Optional
 import logging
 
@@ -24,7 +25,11 @@ def dequote(string: str) -> str:
         return string.lstrip('"').rstrip('"')
     else:
         return string
-
+#TODO adjust grammar to handle apostrophes
+def prepare_phrase(phrase:str) ->str:
+    phrase = phrase.replace("'", " ")
+    phrase = phrase.replace("  ", " ")
+    return phrase
 
 def find_in_phrase(phrase: str, to_find: str) -> bool:
     """Will return True if `to_find` is found in `phrase`. The search is done

--- a/babble/nlp/parser.py
+++ b/babble/nlp/parser.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import List, Dict, Optional
 import logging
 
@@ -32,13 +33,14 @@ def find_in_phrase(phrase: str, to_find: str) -> bool:
     levensthein is done"""
 
     # Try to get a direct match
-    if phrase.find(to_find) > -1:
+    regex=re.compile(r"\b"+to_find +r"\b")
+    if re.match(regex, phrase):
         return True  # Fine! we have a exact match
 
     # Ok, lets do a fuzzy match.
     words_to_test = []
     max_distance = int(len(to_find) / 5)
-
+    
     # The fuzzy match is done my building the phrase in reversed order! This is
     # because the phrase might have grown with every new call:
     # foo -> foo bar -> foo bar baz

--- a/babble/nlp/parser.py
+++ b/babble/nlp/parser.py
@@ -25,13 +25,37 @@ def dequote(string: str) -> str:
         return string.lstrip('"').rstrip('"')
     else:
         return string
-        
-#TODO adjust grammar to handle apostrophes
-def prepare_phrase(phrase:str) ->str:
-    pattern =  re.compile(r"\'")
-    phrase = re.sub(pattern, " ", phrase)
-    phrase = phrase.replace("  ", " ")
+
+
+# TODO adjust grammar to handle apostrophes
+def remove_apostrophe(phrase: str) -> str:
+    dequoted_phrase = False
+    dequoted_word = False
+    phrase = phrase.strip()
+    if phrase.startswith("'") and phrase.endswith("'"):
+        phrase = dequote(phrase)
+        dequoted_phrase = True
+    words = phrase.split(" ")
+    phrase_as_dict = {key: "" for key in list(range(len(words)))}
+    for key in phrase_as_dict.keys():
+        phrase_as_dict.update({key: words[key]})
+
+    key_list = list(phrase_as_dict.keys())
+    for key in key_list:
+        word = phrase_as_dict[key]
+        if word.startswith("'") and word.endswith("'"):
+            word = dequote(word).strip()
+            dequoted_word = True
+        word = word.split("'")[0]
+        if dequoted_word:
+            word = "'" + word + "'"
+            dequoted_word = False
+        phrase_as_dict.update({key: word})
+    phrase = " ".join(list(phrase_as_dict.values()))
+    if dequoted_phrase:
+        phrase = "'" + phrase + "'"
     return phrase
+
 
 def find_in_phrase(phrase: str, to_find: str) -> bool:
     """Will return True if `to_find` is found in `phrase`. The search is done
@@ -39,14 +63,14 @@ def find_in_phrase(phrase: str, to_find: str) -> bool:
     levensthein is done"""
 
     # Try to get a direct match
-    regex=re.compile(r"\b{to_find}\b")
+    regex = re.compile(r"\b" + to_find + r"\b")
     if re.match(regex, phrase):
         return True  # Fine! we have a exact match
 
     # Ok, lets do a fuzzy match.
     words_to_test = []
     max_distance = int(len(to_find) / 5)
-    
+
     # The fuzzy match is done my building the phrase in reversed order! This is
     # because the phrase might have grown with every new call:
     # foo -> foo bar -> foo bar baz

--- a/babble/nlp/parser.py
+++ b/babble/nlp/parser.py
@@ -25,9 +25,11 @@ def dequote(string: str) -> str:
         return string.lstrip('"').rstrip('"')
     else:
         return string
+        
 #TODO adjust grammar to handle apostrophes
 def prepare_phrase(phrase:str) ->str:
-    phrase = phrase.replace("'", " ")
+    pattern =  re.compile(r"\'")
+    phrase = re.sub(pattern, " ", phrase)
     phrase = phrase.replace("  ", " ")
     return phrase
 

--- a/babble/nlp/parser.py
+++ b/babble/nlp/parser.py
@@ -33,7 +33,7 @@ def find_in_phrase(phrase: str, to_find: str) -> bool:
     levensthein is done"""
 
     # Try to get a direct match
-    regex=re.compile(r"\b"+to_find +r"\b")
+    regex=re.compile(r"\b{to_find}\b")
     if re.match(regex, phrase):
         return True  # Fine! we have a exact match
 

--- a/tests/nlp/test.domain.json
+++ b/tests/nlp/test.domain.json
@@ -67,7 +67,7 @@
 	{
 		"type": "intent",
 		"name": "apostrophe",
-		"rule": "here s apostrophe"
+		"rule": "here apostrophe"
 	}
 
 ]

--- a/tests/nlp/test.domain.json
+++ b/tests/nlp/test.domain.json
@@ -63,5 +63,11 @@
 		"type": "entity",
 		"name": "triplenumber",
 		"rule": "<number> <number> <number>"
+	},
+	{
+		"type": "intent",
+		"name": "apostrophe",
+		"rule": "here s apostrophe"
 	}
+
 ]

--- a/tests/nlp/test_engine.py
+++ b/tests/nlp/test_engine.py
@@ -20,7 +20,7 @@ def test_intents_are_sorted(engine: Engine):
         ("foo bar xxx", True, "my_foo_bar_intent"),
         ("xxx foo bar baz", True, "my_xxx_foo_bar_baz_intent"),
         ("zzz foo bar baz", True, "my_foo_bar_baz_intent"),
-        ("here 's apostroph", True, "apostrophe"),
+        ("here's apostrophe", True, "apostrophe"),
         ("zzz foo baz bar", True, "my_foo_bar_intent"),
         ("zzz baz bar zzz", False, ""),
     ],

--- a/tests/nlp/test_engine.py
+++ b/tests/nlp/test_engine.py
@@ -20,6 +20,7 @@ def test_intents_are_sorted(engine: Engine):
         ("foo bar xxx", True, "my_foo_bar_intent"),
         ("xxx foo bar baz", True, "my_xxx_foo_bar_baz_intent"),
         ("zzz foo bar baz", True, "my_foo_bar_baz_intent"),
+        ("here 's apostroph", True, "apostrophe"),
         ("zzz foo baz bar", True, "my_foo_bar_intent"),
         ("zzz baz bar zzz", False, ""),
     ],


### PR DESCRIPTION
if a parsed phrase doesn't completely match a phrase it compared with to, it cannot be classified as an "exact match". E.g. "no" is not an exact match for "not".

function to remove an apostrophe from a phrase is added, so lark doesn't break